### PR TITLE
chore: delete ineffective jquery import

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -9,7 +9,6 @@
     <script src="nui://game/ui/jquery.js" type="text/javascript"></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-    <script type="text/javascript" src="includes/jquery-1.4.2.min.js"></script>
     <title>QB-Multicharacter</title>
 </head>
     <body>


### PR DESCRIPTION
Jquery is already imported with cdn, no need to re-import a file that doesn't exist.