### PR TITLE
Fix "My Character" cut off

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -39,7 +39,7 @@
 
     .character-list-header {
         text-transform: uppercase;
-        position: absolute;
+        position: relative;
         top: -2vh;
         width: 100%;
         height: 10%;


### PR DESCRIPTION
When selecting the first character slot, the 'My Character' text gets cut off when using 1440p monitor resolutions. Originally fixed by Mystic in the QB-Core Discord. 
https://discord.com/channels/831626422232678481/868498908819619900/877780765423837185