### PR TITLE
NUI Callback resolve with 200 response to stop hanging

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -92,26 +92,29 @@ end)
 
 -- NUI Callbacks
 
-RegisterNUICallback('closeUI', function()
+RegisterNUICallback('closeUI', function(_, cb)
     openCharMenu(false)
+    cb("ok")
 end)
 
-RegisterNUICallback('disconnectButton', function()
+RegisterNUICallback('disconnectButton', function(_, cb)
     SetEntityAsMissionEntity(charPed, true, true)
     DeleteEntity(charPed)
     TriggerServerEvent('qb-multicharacter:server:disconnect')
+    cb("ok")
 end)
 
-RegisterNUICallback('selectCharacter', function(data)
+RegisterNUICallback('selectCharacter', function(data, cb)
     local cData = data.cData
     DoScreenFadeOut(10)
     TriggerServerEvent('qb-multicharacter:server:loadUserData', cData)
     openCharMenu(false)
     SetEntityAsMissionEntity(charPed, true, true)
     DeleteEntity(charPed)
+    cb("ok")
 end)
 
-RegisterNUICallback('cDataPed', function(data)
+RegisterNUICallback('cDataPed', function(data, cb)
     local cData = data.cData  
     SetEntityAsMissionEntity(charPed, true, true)
     DeleteEntity(charPed)
@@ -152,6 +155,7 @@ RegisterNUICallback('cDataPed', function(data)
                     SetBlockingOfNonTemporaryEvents(charPed, true)
                 end)
             end
+            cb("ok")
         end, cData.citizenid)
     else
         CreateThread(function()
@@ -171,23 +175,26 @@ RegisterNUICallback('cDataPed', function(data)
             PlaceObjectOnGroundProperly(charPed)
             SetBlockingOfNonTemporaryEvents(charPed, true)
         end)
+        cb("ok")
     end
 end)
 
-RegisterNUICallback('setupCharacters', function()
+RegisterNUICallback('setupCharacters', function(data, cb)
     QBCore.Functions.TriggerCallback("qb-multicharacter:server:setupCharacters", function(result)
         SendNUIMessage({
             action = "setupCharacters",
             characters = result
         })
+        cb("ok")
     end)
 end)
 
-RegisterNUICallback('removeBlur', function()
+RegisterNUICallback('removeBlur', function(data, cb)
     SetTimecycleModifier('default')
+    cb("ok")
 end)
 
-RegisterNUICallback('createNewCharacter', function(data)
+RegisterNUICallback('createNewCharacter', function(data, cb)
     local cData = data
     DoScreenFadeOut(150)
     if cData.gender == "Male" then
@@ -197,9 +204,21 @@ RegisterNUICallback('createNewCharacter', function(data)
     end
     TriggerServerEvent('qb-multicharacter:server:createCharacter', cData)
     Wait(500)
+    cb("ok")
 end)
 
-RegisterNUICallback('removeCharacter', function(data)
+RegisterNUICallback('removeCharacter', function(data, cb)
     TriggerServerEvent('qb-multicharacter:server:deleteCharacter', data.citizenid)
     TriggerEvent('qb-multicharacter:client:chooseChar')
+    cb("ok")
+end)
+
+RegisterNUICallback('fix', function(data, cb)
+    Wait(0)
+    if NetworkIsSessionStarted() then
+        TriggerEvent('qb-multicharacter:client:chooseChar')
+        cb("ok")
+        return
+    end
+    cb(data)
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -212,13 +212,3 @@ RegisterNUICallback('removeCharacter', function(data, cb)
     TriggerEvent('qb-multicharacter:client:chooseChar')
     cb("ok")
 end)
-
-RegisterNUICallback('fix', function(data, cb)
-    Wait(0)
-    if NetworkIsSessionStarted() then
-        TriggerEvent('qb-multicharacter:client:chooseChar')
-        cb("ok")
-        return
-    end
-    cb(data)
-end)


### PR DESCRIPTION
This Pull Request is intended to statisfy the standard requirements set out by HTTP whereby, the behaviour over TCP requires a request-response structure and an application utilising HTTP as a communication protocol will wait for a response unless terminated by the application due to a timeout.

QB-Multicharacter uses `jQuery::post` and makes use of the second callback parameter which only cares about an HTTP 200 response.

Not all NUICallbacks within QB-Multicharacter respond to their requests. This leaves the request hanging indefinitely as the application in question (FIVEM/CEF) does not timeout these requests.

Calling the callback function (available in callback function argument #2 of `RegisterNUICallback`) terminates the request with a plaintext body "OK" 200 response and closes the request.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **Yes**
- Does your PR fit the contribution guidelines? **Yes**


**NB** I left out the emoji annotation. But this is a mix of :art: and :racehorse: as well as overall good practice.