### PR TITLE
:bug: remove spaces in nationality

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -192,7 +192,15 @@ function escapeHtml(string) {
 }
 function hasWhiteSpace(s) {
     return /\s/g.test(s);
-  }
+}
+
+$('#nationality').keyup(function() {
+    var nationalityValue = $(this).val();
+    if(nationalityValue.indexOf(' ') !== -1) {
+        $(this).val(nationalityValue.replace(' ', ''))
+    }
+});
+
 $(document).on('click', '#create', function (e) {
     e.preventDefault();
 


### PR DESCRIPTION
It is known that the character registration form does not pass validation if there are spaces in nationality. No information is communicated to the user in this regard.

Sticking with the current development pattern, a small jQuery code excerpt has been added in to this branch that simply strips the space when a user releases the key using the REPLACE method of the STRING class.

There is no outstanding issue for this fix. Nor would I necessarily call it a bug. But it was the only thing that seemed to fit the category.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **Yes**
- Does your PR fit the contribution guidelines? **Yes**
