### PR TITLE
Show errors when creating a new character

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -192,7 +192,11 @@ function escapeHtml(string) {
 }
 function hasWhiteSpace(s) {
     return /\s/g.test(s);
-  }
+}
+function setError(e) {
+    $('.char-register-error').text(e)
+    $('.char-register-error').css('display', 'block')
+}
 $(document).on('click', '#create', function (e) {
     e.preventDefault();
 
@@ -206,12 +210,12 @@ $(document).on('click', '#create', function (e) {
     //An Ugly check of null objects
 
     if (!firstname || !lastname || !nationality || !birthdate || hasWhiteSpace(firstname) || hasWhiteSpace(lastname)|| hasWhiteSpace(nationality) ){
-        console.log("FIELDS REQUIRED")
+        setError("Please fill all fields")
         return false;
     }
 
     if(regTest.test(firstname) || regTest.test(lastname)){
-        console.log("ERROR: You used a derogatory/vulgar term. Please try again!")
+        setError("You used a derogatory/vulgar term. Please try again!")
         return false;
     }
 

--- a/html/style.css
+++ b/html/style.css
@@ -315,7 +315,7 @@
     display: none;
     position: relative;
     width: 25%;
-    height: 32%;
+    max-height: 40%;
     top: 125%;
     margin-left: auto;
     margin-right: auto;
@@ -325,6 +325,7 @@
     padding: 30px;
     font-family: 'Poppins', sans-serif;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+    overflow: visible;
 }
 
 i#close-reg {
@@ -345,29 +346,20 @@ i#close-reg {
 
 .characters-register-block-header {
     text-transform: uppercase;
-    position: absolute;
     width: 100%;
-    height: 12vh;
     color: #ededed;
     text-align: left;
     font-size: 2vh;
     font-weight: 900;
 }
 
-.char-register-inputs {
-    position: absolute;
-    top: 14%;
-    overflow: visible !important;
-}
 
 .char-reg-input {
-    position: relative;
-    float: left;
     margin-top: 1vh;
     border: none;
     background-color: #444444;
     outline: none;
-    width: 92%;
+    width: 100%;
     height: 3vh;
     color: #ededed;
     max-width: 100%;
@@ -380,18 +372,27 @@ i#close-reg {
     cursor: text;
 }
 
+.char-register-error {
+    color: red;
+    font-weight: 900;
+    font-size: 2vh;
+    text-align: center;
+    padding: 1vh 0;
+    display: none;
+}
+
 select {
-    position: absolute;
     border: none;
     border: .3vh solid #444444;
     background-color: #171717;
     outline: none;
-    width: 93.5%;
+    width: 100%;
     height: 4vh;
     top: 19.9vh;
     left: .1vh;
     color: #ededed;
     max-width: 100%;
+    margin-top: 1vh;
     padding: 4px;
     border-radius: .3vh;
     font-family: 'Poppins', sans-serif;
@@ -460,16 +461,12 @@ input[type="date"]::-webkit-clear-button {
 }
 
 .character-reg-btn {
-    position: absolute;
-    max-width: 87%;
+    width: 100%;
     height: 4vh;
     background-color: #dc143c;
     border-radius: .3vh;
-    bottom: 3vh;
-    margin: 0 auto;
-    left: 0;
-    right: 0;
     cursor: pointer;
+    margin-top: 1vh;
 }
 
 .character-reg-btn>p {


### PR DESCRIPTION
Currently, if you incorrectly fill out the character creation form you are not informed.

This happens in 2 cases:
- When not all fields are filled
- When the play name fails to profanity filter

This change adds an error message that is displayed.


![20220312105938_1](https://user-images.githubusercontent.com/169987/157994724-fbf1d09f-540b-41ea-b325-8378a4d7ec75.jpg)
![20220312105940_1](https://user-images.githubusercontent.com/169987/157994739-c6a7959a-32ac-45d2-9d24-0c7a2e34c534.jpg)
![20220312110000_1](https://user-images.githubusercontent.com/169987/157994745-ea83d246-8bd9-4722-aabd-547e4c40d874.jpg)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Unsure, can't find guidelines. I've kept it consistent with current code base.
- Does your PR fit the contribution guidelines? Yes
