### PR TITLE
Added trim to create character fields

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -202,12 +202,12 @@ function hasWhiteSpace(s) {
 $(document).on('click', '#create', function (e) {
     e.preventDefault();
 
-    let firstname= escapeHtml($('#first_name').val())
-    let lastname= escapeHtml($('#last_name').val())
-    let nationality= escapeHtml($('#nationality').val())
-    let birthdate= escapeHtml($('#birthdate').val())
-    let gender= escapeHtml($('select[name=gender]').val())
-    let cid = escapeHtml($(selectedChar).attr('id').replace('char-', ''))
+    let firstname= $.trim(escapeHtml($('#first_name').val()))
+    let lastname= $.trim(escapeHtml($('#last_name').val()))
+    let nationality= $.trim(escapeHtml($('#nationality').val()))
+    let birthdate= $.trim(escapeHtml($('#birthdate').val()))
+    let gender= $.trim(escapeHtml($('select[name=gender]').val()))
+    let cid = $.trim(escapeHtml($(selectedChar).attr('id').replace('char-', '')))
     const regTest = new RegExp(profList.join('|'), 'i');
     //An Ugly check of null objects
 


### PR DESCRIPTION
**Describe Pull request**
Further to https://github.com/qbcore-framework/qb-multicharacter/pull/122 this adds a trim to each field to remove only the whitespace at the start and the end of the string, allowing spaces in between words.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
