### PR TITLE
Update regex to match word case. Fixes #79

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -210,8 +210,8 @@ $(document).on('click', '#create', function (e) {
     let birthdate= $.trim(escapeHtml($('#birthdate').val()))
     let gender= $.trim(escapeHtml($('select[name=gender]').val()))
     let cid = $.trim(escapeHtml($(selectedChar).attr('id').replace('char-', '')))
-    const regTest = new RegExp(profList.join('|'), 'i');
-    //An Ugly check of null objects
+    let re = '(' + profList.join('|') + ')\\b'
+    const regTest = new RegExp(re, 'i');
 
     if (!firstname || !lastname || !nationality || !birthdate){
         var reqFieldErr = '<p>You are missing required fields!</p>'


### PR DESCRIPTION
**Describe Pull request**
This is an update to the RegEx used in the profanity filter. This update will only match word cases so will prevent names such as "Michelle" from being blocked for having the word "hell" within the name. Now, character creation will only be blocked if the user tries to call themself the exact word "hell" for example.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no - tested on  [codepen](https://codepen.io/tom-osborne/pen/YzapMEx)  & [regexr](https://regexr.com/6prc7) ] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
