### PR TITLE
Import qb-apartments config for start apartment setting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           capture: "junit.xml"
           args: "-t --formatter JUnit"
-          extra_libs: mysql+polyzone+qblocales
+          extra_libs: mysql+polyzone+qblocales+qbapartments
       - name: Generate Lint Report
         if: always()
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           capture: "junit.xml"
           args: "-t --formatter JUnit"
-          extra_libs: mysql+polyzone+qblocales+qbapartments
+          extra_libs: mysql+polyzone+qblocales
       - name: Generate Lint Report
         if: always()
         uses: mikepenz/action-junit-report@v3

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,4 @@
 Config = {}
-Config.StartingApartment = true -- Enable/disable starting apartments (make sure to set default spawn coords)
 Config.Interior = vector3(-814.89, 181.95, 76.85) -- Interior to load where characters are previewed
 Config.DefaultSpawn = vector3(-1035.71, -2731.87, 12.86) -- Default spawn coords if you have start apartments disabled
 Config.PedCoords = vector4(-813.97, 176.22, 76.74, -7.5) -- Create preview ped at these coordinates

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,6 +8,7 @@ shared_script 'config.lua'
 client_script 'client/main.lua'
 server_scripts  {
     '@oxmysql/lib/MySQL.lua',
+    '@qb-apartments/config.lua',
     'server/main.lua'
 }
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -93,7 +93,7 @@ RegisterNetEvent('qb-multicharacter:server:createCharacter', function(data)
     newData.cid = data.cid
     newData.charinfo = data
     if QBCore.Player.Login(src, false, newData) then
-        if Config.StartingApartment then
+        if Apartments.Starting then
             local randbucket = (GetPlayerPed(src) .. math.random(1,999))
             SetPlayerRoutingBucket(src, randbucket)
             print('^2[qb-core]^7 '..GetPlayerName(src)..' has succesfully loaded!')


### PR DESCRIPTION
**Describe Pull request**
qb-apartments config imported to make use of the start apartment setting. User now only needs to set this in one place, rather than two.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
