### PR TITLE
Add admin command (new and improved)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -214,30 +214,3 @@ RegisterNUICallback('removeCharacter', function(data, cb)
     TriggerEvent('qb-multicharacter:client:chooseChar')
     cb("ok")
 end)
-
-RegisterCommand("deletechar", function(source, args, raw)
-    QBCore.Functions.TriggerCallback("qb-multicharacter:server:hasaccess", function(result)
-        if result then
-            local data = exports['qb-input']:ShowInput({
-                header = "To remove a players character please input the following information",
-                submitText = "Delete Character",
-                inputs = {
-                    {
-                        type = 'text',
-                        isRequired = true,
-                        name = 'citizenid',
-                        text = "Citizen ID"
-                    }
-                }
-            })
-            if data and data.citizenid then
-                TriggerServerEvent("qb-multicharacter:server:removechar", data.citizenid)
-            else
-                QBCore.Functions.Notify("You failed to input the needed parameters")
-            end
-        else
-            QBCore.Functions.Notify("You don't have access to this command")
-        end
-    end)
-end)
-TriggerEvent('chat:addSuggestion', '/deletechar', 'Delete a players character', {})

--- a/client/main.lua
+++ b/client/main.lua
@@ -214,3 +214,30 @@ RegisterNUICallback('removeCharacter', function(data, cb)
     TriggerEvent('qb-multicharacter:client:chooseChar')
     cb("ok")
 end)
+
+RegisterCommand("deletechar", function(source, args, raw)
+    QBCore.Functions.TriggerCallback("qb-multicharacter:server:hasaccess", function(result)
+        if result then
+            local data = exports['qb-input']:ShowInput({
+                header = "To remove a players character please input the following information",
+                submitText = "Delete Character",
+                inputs = {
+                    {
+                        type = 'text',
+                        isRequired = true,
+                        name = 'citizenid',
+                        text = "Citizen ID"
+                    }
+                }
+            })
+            if data and data.citizenid then
+                TriggerServerEvent("qb-multicharacter:server:removechar", data.citizenid)
+            else
+                QBCore.Functions.Notify("You failed to input the needed parameters")
+            end
+        else
+            QBCore.Functions.Notify("You don't have access to this command")
+        end
+    end)
+end)
+TriggerEvent('chat:addSuggestion', '/deletechar', 'Delete a players character', {})

--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,7 @@ Config.PedCoords = vector4(-813.97, 176.22, 76.74, -7.5) -- Create preview ped a
 Config.HiddenCoords = vector4(-812.23, 182.54, 76.74, 156.5) -- Hides your actual ped while you are in selection
 Config.CamCoords = vector4(-813.46, 178.95, 76.85, 174.5) -- Camera coordinates for character preview screen
 Config.EnableDeleteButton = true -- Define if the player can delete the character or not
+Config.AllowAdminDeleteCommand = false -- If set to true it will allow "gods" to use the /deletechar command to delete any character they want to
 
 Config.DefaultNumberOfCharacters = 5 -- Define maximum amount of default characters (maximum 5 characters defined by default)
 Config.PlayersNumberOfCharacters = { -- Define maximum amount of player characters by rockstar license (you can find this license in your server's database in the player table)

--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,6 @@ Config.PedCoords = vector4(-813.97, 176.22, 76.74, -7.5) -- Create preview ped a
 Config.HiddenCoords = vector4(-812.23, 182.54, 76.74, 156.5) -- Hides your actual ped while you are in selection
 Config.CamCoords = vector4(-813.46, 178.95, 76.85, 174.5) -- Camera coordinates for character preview screen
 Config.EnableDeleteButton = true -- Define if the player can delete the character or not
-Config.AllowAdminDeleteCommand = false -- If set to true it will allow "gods" to use the /deletechar command to delete any character they want to
 
 Config.DefaultNumberOfCharacters = 5 -- Define maximum amount of default characters (maximum 5 characters defined by default)
 Config.PlayersNumberOfCharacters = { -- Define maximum amount of player characters by rockstar license (you can find this license in your server's database in the player table)

--- a/server/main.lua
+++ b/server/main.lua
@@ -178,59 +178,40 @@ QBCore.Functions.CreateCallback("qb-multicharacter:server:getSkin", function(_, 
     end
 end)
 
-if Config.AllowAdminDeleteCommand == true then
-    local playertables = { -- Add tables as needed
-        { table = 'players' },
-        { table = 'apartments' },
-        { table = 'bank_accounts' },
-        { table = 'crypto_transactions' },
-        { table = 'phone_invoices' },
-        { table = 'phone_messages' },
-        { table = 'playerskins' },
-        { table = 'player_contacts' },
-        { table = 'player_houses' },
-        { table = 'player_mails' },
-        { table = 'player_outfits' },
-        { table = 'player_vehicles' }
-    }
+QBCore.Commands.Add("deletechar", "Deletes another players character", {{name = "Citizen ID", help = "The Citizen ID of the character you want to delete"}}, false, function(source,args)
+    local Player = QBCore.Functions.GetPlayer(source)
 
-    function hasAccess(src, rank)
-        if QBCore.Functions.HasPermission(src, rank) or IsPlayerAceAllowed(src, 'command') then
-            return true
-        else
-            return false
+    if args and args[1] then
+        local Target = QBCore.Functions.GetPlayerByCitizenId(tostring(args[1]))
+
+        if Target then
+            DropPlayer(Target.PlayerData.source, "An admin deleted the character which you are currently using")
         end
+
+        QBCore.Player.ForceDeleteCharacter(tostring(args[1]))
+        TriggerClientEvent("QBCore:Notify", Player.PlayerData.source, "You successfully deleted the character with citizen id \"" .. tostring(args[1]) .. "\".")
+    else
+        TriggerClientEvent("QBCore:Notify", Player.PlayerData.source, "You forgot to input a citizen id", "error")
+    end
+end, "god")
+
+RegisterNetEvent("qb-multicharacter:server:removechar")
+AddEventHandler("qb-multicharacter:server:removechar", function(citizenid)
+    local Target = QBCore.Functions.GetPlayerByCitizenId(citizenid)
+    if Target then
+        Target.Functions.Logout()
+        TriggerClientEvent('qb-multicharacter:client:chooseChar', Target.PlayerData.source)
+        TriggerClientEvent("QBCore:Notify", Target.PlayerData.source, "Your character got deleted by an admin")
     end
 
-    QBCore.Functions.CreateCallback('qb-multicharacter:server:hasaccess', function(source, cb)
-        cb(hasAccess(source, "god"))
-    end)
+    local queries = table.create(#playertables, 0)
+    for i = 1, #playertables do
+        queries[i] = {query = ("DELETE FROM %s WHERE citizenid = ?"):format(playertables[i].table), values = {citizenid}}
+    end
 
-    RegisterNetEvent("qb-multicharacter:server:removechar")
-    AddEventHandler("qb-multicharacter:server:removechar", function(citizenid)
-        local Player = QBCore.Functions.GetPlayer(source)
-
-        if Player == nil then return end
-        if hasAccess(Player.PlayerData.source, "god") then
-            local Target = QBCore.Functions.GetPlayerByCitizenId(citizenid)
-            if Target then
-                Target.Functions.Logout()
-                TriggerClientEvent('qb-multicharacter:client:chooseChar', Target.PlayerData.source)
-                TriggerClientEvent("QBCore:Notify", Target.PlayerData.source, "Your character got deleted by an admin")
-            end
-
-            local queries = table.create(#playertables, 0)
-            for i = 1, #playertables do
-                queries[i] = {query = ("DELETE FROM %s WHERE citizenid = ?"):format(playertables[i].table), values = {citizenid}}
-            end
-
-            MySQL.transaction(queries, function(result2)
-                if result2 then
-                    TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Deleted By Admin', 'red', '**' .. GetPlayerName(Target.PlayerData.source) .. '** ' .. Target.PlayerData.license .. ' deleted **' .. citizenid .. '**, deleted by **' .. GetPlayerName(Player.PlayerData.source) .. "** (**" .. Player.PlayerData.license .. "**)")
-                end
-            end)
-        else
-            DropPlayer(Player.PlayerData.source, "Exploiting")
+    MySQL.transaction(queries, function(result2)
+        if result2 then
+            TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Deleted By Admin', 'red', '**' .. GetPlayerName(Target.PlayerData.source) .. '** ' .. Target.PlayerData.license .. ' deleted **' .. citizenid .. '**, deleted by **' .. GetPlayerName(Player.PlayerData.source) .. "** (**" .. Player.PlayerData.license .. "**)")
         end
     end)
-end
+end)


### PR DESCRIPTION
This adds the admin command suggested in issue #76.
Via this command god users can delete other players characters upon need for it

**Describe Pull request**
This has been added since it allows server owners and high staff members to control their characters alot easierly. Maybe you dont want to give out the entire VPS / SQL access to someone just so they can delete characters from someone, well this solves the issue. This can now be done ingame instead!

If your PR is to fix an issue mention that issue here 
issue #76

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
Yes
- Does your code fit the style guidelines? [yes/no]
Yes, my code should fit the style guidelines
- Does your PR fit the contribution guidelines? [yes/no]
Yes, I dont see any issue with this PR
