### PR TITLE
Scroll Bar Fix!

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -12,9 +12,9 @@
 .characters-list {
     position: absolute;
     min-width: 26%;
-    width: fit-contentss;
+    width: fit-content;
     min-height: 50%;
-    height: fit-contents;
+    height: fit-content;
     max-height: 70%;
     left: 14%;
     top: 20%;
@@ -155,10 +155,10 @@
 
 .character-info {
     min-width: 22.5%;
-    width: fit-contents;
+    width: fit-content;
     max-width: 27.5%;
     min-height: 50%;
-    height: fit-contents;
+    height: fit-content;
 
     position: absolute;
     right: 14%;
@@ -291,7 +291,7 @@
 .character-register {
     position: relative;
     width: 25%;
-    height: fit-contents;
+    height: fit-content;
     top: 50%;
     transform: translateY(-50%);
     margin-left: auto;

--- a/html/style.css
+++ b/html/style.css
@@ -12,9 +12,9 @@
 .characters-list {
     position: absolute;
     min-width: 26%;
-    width: fit-contents;
+    width: fit-contentss;
     min-height: 50%;
-    height: fit-content;
+    height: fit-contents;
     max-height: 70%;
     left: 14%;
     top: 20%;
@@ -155,10 +155,10 @@
 
 .character-info {
     min-width: 22.5%;
-    width: fit-content;
+    width: fit-contents;
     max-width: 27.5%;
     min-height: 50%;
-    height: fit-content;
+    height: fit-contents;
 
     position: absolute;
     right: 14%;
@@ -291,7 +291,7 @@
 .character-register {
     position: relative;
     width: 25%;
-    height: fit-content;
+    height: fit-contents;
     top: 50%;
     transform: translateY(-50%);
     margin-left: auto;

--- a/html/style.css
+++ b/html/style.css
@@ -25,8 +25,6 @@
     transition: 400ms;
 }
 
-
-
 .character-list-header {
     text-transform: uppercase;
     position: relative;

--- a/html/style.css
+++ b/html/style.css
@@ -12,7 +12,7 @@
 .characters-list {
     position: absolute;
     min-width: 26%;
-    width: fit-content;
+    width: fit-contents;
     min-height: 50%;
     height: fit-content;
     max-height: 70%;
@@ -49,15 +49,28 @@
 .characters {
     width: 100%;
     height: 32vh;
-    overflow-y: scroll!important;
+    overflow-y: auto!important;
     overflow-x: hidden!important;
     -ms-overflow-style: none;
 }
 
 .characters::-webkit-scrollbar {
-    display: none;
+    display: auto;
 }
 
+.characters::-webkit-scrollbar {
+    width:1vh;
+}
+.characters::-webkit-scrollbar-track {
+    border-radius:20px;
+    border:1px solid #000000;
+    background:#000000;
+}
+.characters::-webkit-scrollbar-thumb {
+    border-radius:20px;
+    border:1px solid #000000;
+    background-color:#a90d2ca6;
+}
 .character {
     position: relative;
     width: 100%;

--- a/html/style.css
+++ b/html/style.css
@@ -1,9 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@100&display=swap');
 
-.characters::-webkit-scrollbar {
-    display:none;
-} 
-
 .main-screen {
     position: absolute;
     height: 100vh;
@@ -27,18 +23,9 @@
     box-shadow: rgb(0 0 0 / 16%) 0px 3px 6px, rgb(0 0 0 / 23%) 0px 3px 6px;
     padding: 30px;
     transition: 400ms;
-
-    overflow-y: scroll!important;
-    overflow-x: hidden!important;
-
-    -ms-overflow-style: none;
-    scrollbar-width: none;
 }
 
-.characters-list::-webkit-scrollbar {
-    display: none;
-}
-  
+
 
 .character-list-header {
     text-transform: uppercase;
@@ -47,7 +34,7 @@
     width: 100%;
     height: 10%;
     right: 0;
-} 
+}
 
 .character-list-header>p {
     text-align: center;
@@ -61,7 +48,14 @@
 
 .characters {
     width: 100%;
-    height: 72.5%;
+    height: 32vh;
+    overflow-y: scroll!important;
+    overflow-x: hidden!important;
+    -ms-overflow-style: none;
+}
+
+.characters::-webkit-scrollbar {
+    display: none;
 }
 
 .character {
@@ -193,7 +187,7 @@
     margin-top: 25px;
 }
 
-.character-info table, 
+.character-info table,
 .character-info tbody,
 .character-info tr,
 .character-info td {

--- a/html/style.css
+++ b/html/style.css
@@ -52,6 +52,7 @@
     overflow-y: auto!important;
     overflow-x: hidden!important;
     -ms-overflow-style: none;
+    padding-right: 10px;
 }
 
 .characters::-webkit-scrollbar {


### PR DESCRIPTION
the buttons are at the bottom of the list
this means when you have a lot of character slots you have to scroll to the bottom to get to the button.

I made it so you don't have to scroll to see the buttons by moving the overflow and scroll buttons from the characters-list div to the characters div and I resized the characters element to allow the buttons to be viewable.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
