### PR TITLE
Fix character spawning issue when Config.SkipSelection is true

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -142,25 +142,23 @@ RegisterNetEvent('qb-multicharacter:client:spawnLastLocation', function(coords, 
     SetEntityHeading(ped, coords.w)
     FreezeEntityPosition(ped, false)
     SetEntityVisible(ped, true)
+    local PlayerData = QBCore.Functions.GetPlayerData()
+    local insideMeta = PlayerData.metadata["inside"]
+    DoScreenFadeOut(500)
+
+    local isInsideProperty = function()
+        return insideMeta.house or (insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId)
+    end
+
+    local handleLocation = function()
+        if insideMeta.house then
+            TriggerEvent('qb-houses:client:LastLocationHouse', insideMeta.house)
+        elseif insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId then
+            TriggerEvent('qb-apartments:client:LastLocationHouse', insideMeta.apartment.apartmentType, insideMeta.apartment.apartmentId)
+        end
+    end
 
     QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', function(result)
-        local PlayerData = QBCore.Functions.GetPlayerData()
-        local insideMeta = PlayerData.metadata["inside"]
-
-        DoScreenFadeOut(500)
-
-        local function isInsideProperty()
-            return insideMeta.house or (insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId)
-        end
-
-        local function handleLocation()
-            if insideMeta.house then
-                TriggerEvent('qb-houses:client:LastLocationHouse', insideMeta.house)
-            elseif insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId then
-                TriggerEvent('qb-apartments:client:LastLocationHouse', insideMeta.apartment.apartmentType, insideMeta.apartment.apartmentId)
-            end
-        end
-
         if result then
             TriggerEvent("apartments:client:SetHomeBlip", result.type)
         end
@@ -171,7 +169,6 @@ RegisterNetEvent('qb-multicharacter:client:spawnLastLocation', function(coords, 
 
         TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
         TriggerEvent('QBCore:Client:OnPlayerLoaded')
-
         Wait(2000)
         DoScreenFadeIn(250)
     end, cData.citizenid)

--- a/client/main.lua
+++ b/client/main.lua
@@ -137,34 +137,43 @@ RegisterNetEvent('qb-multicharacter:client:chooseChar', function()
 end)
 
 RegisterNetEvent('qb-multicharacter:client:spawnLastLocation', function(coords, cData)
-    QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', function(result)
-        if result then
-            TriggerEvent("apartments:client:SetHomeBlip", result.type)
-            local ped = PlayerPedId()
-            SetEntityCoords(ped, coords.x, coords.y, coords.z)
-            SetEntityHeading(ped, coords.w)
-            FreezeEntityPosition(ped, false)
-            SetEntityVisible(ped, true)
-            local PlayerData = QBCore.Functions.GetPlayerData()
-            local insideMeta = PlayerData.metadata["inside"]
-            DoScreenFadeOut(500)
+    local ped = PlayerPedId()
+    SetEntityCoords(ped, coords.x, coords.y, coords.z)
+    SetEntityHeading(ped, coords.w)
+    FreezeEntityPosition(ped, false)
+    SetEntityVisible(ped, true)
 
+    QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', function(result)
+        local PlayerData = QBCore.Functions.GetPlayerData()
+        local insideMeta = PlayerData.metadata["inside"]
+
+        DoScreenFadeOut(500)
+
+        local function isInsideProperty()
+            return insideMeta.house or (insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId)
+        end
+
+        local function handleLocation()
             if insideMeta.house then
                 TriggerEvent('qb-houses:client:LastLocationHouse', insideMeta.house)
             elseif insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId then
                 TriggerEvent('qb-apartments:client:LastLocationHouse', insideMeta.apartment.apartmentType, insideMeta.apartment.apartmentId)
-            else
-                SetEntityCoords(ped, coords.x, coords.y, coords.z)
-                SetEntityHeading(ped, coords.w)
-                FreezeEntityPosition(ped, false)
-                SetEntityVisible(ped, true)
             end
-
-            TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
-            TriggerEvent('QBCore:Client:OnPlayerLoaded')
-            Wait(2000)
-            DoScreenFadeIn(250)
         end
+
+        if result then
+            TriggerEvent("apartments:client:SetHomeBlip", result.type)
+        end
+
+        if isInsideProperty() then
+            handleLocation()
+        end
+
+        TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
+        TriggerEvent('QBCore:Client:OnPlayerLoaded')
+
+        Wait(2000)
+        DoScreenFadeIn(250)
     end, cData.citizenid)
 end)
 


### PR DESCRIPTION
### **Fix character spawning issue when Config.SkipSelection is true:**

Previously, when using the **/logout** command with Config.SkipSelection set to true, the character was unable to spawn back in. This was because the lastspawnlocation event was triggering apartment-related events and setting the home blip even when Config.SkipSelection was true.

The updated code introduces two new functions: _isInsideProperty()_ and _handleLocation()_. These functions encapsulate the logic for checking if the player is inside a property and handling the appropriate events based on the player's location.

```
RegisterNetEvent('qb-multicharacter:client:spawnLastLocation', function(coords, cData)
    -- Set the player's ped to the last known coordinates and heading
    local ped = PlayerPedId()
    SetEntityCoords(ped, coords.x, coords.y, coords.z)
    SetEntityHeading(ped, coords.w)
    FreezeEntityPosition(ped, false)
    SetEntityVisible(ped, true)

    -- Trigger a callback to get the player's owned apartment
    QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', function(result)
        -- Get the player's data and metadata
        local PlayerData = QBCore.Functions.GetPlayerData()
        local insideMeta = PlayerData.metadata["inside"]

        -- Start a screen fade out effect
        DoScreenFadeOut(500)

        -- Function to check if the player is inside a house or apartment
        local function isInsideProperty()
            return insideMeta.house or (insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId)
        end

        -- Function to handle the player's location and trigger appropriate events
        local function handleLocation()
            if insideMeta.house then
                -- If inside a house, trigger the 'qb-houses:client:LastLocationHouse' event
                TriggerEvent('qb-houses:client:LastLocationHouse', insideMeta.house)
            elseif insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId then
                -- If inside an apartment, trigger the 'qb-apartments:client:LastLocationHouse' event
                TriggerEvent('qb-apartments:client:LastLocationHouse', insideMeta.apartment.apartmentType, insideMeta.apartment.apartmentId)
            end
        end

        -- If the player owns an apartment, set the home blip on the map
        if result then
            TriggerEvent("apartments:client:SetHomeBlip", result.type)
        end

        -- If the player is inside a house or apartment, handle their location
        if isInsideProperty() then
            handleLocation()
        end

        -- Trigger server and client events to indicate the player has loaded
        TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
        TriggerEvent('QBCore:Client:OnPlayerLoaded')

        -- Wait for 2 seconds before starting a screen fade in effect
        Wait(2000)
        DoScreenFadeIn(250)
    end, cData.citizenid)
end)
```
I put the updated code through a bunch of tests to make sure it works reliably in different situations. I tested spawning characters inside houses, apartments, and with _Config.SkipSelection_ set to true and false, no problems where encountered and no errors logged. 