### PR TITLE
Fix AddItem putting a string into the created date field when giving starter items

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -21,7 +21,7 @@ local function GiveStarterItems(source)
             info.birthdate = Player.PlayerData.charinfo.birthdate
             info.type = "Class C Driver License"
         end
-        exports['qb-inventory']:AddItem(src, v.item, v.amount, false, info, 'qb-multicharacter:GiveStarterItems')
+        exports['qb-inventory']:AddItem(src, v.item, v.amount, false, info, os.time())
     end
 end
 


### PR DESCRIPTION
**Describe Pull request**
Fixes starter items putting in a string in the created date field, causing inventories to crash in game when being read from the database.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
