### PR TITLE
Fix a vulnerability regarding character deletion

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -140,6 +140,7 @@ end)
 
 RegisterNetEvent('qb-multicharacter:server:deleteCharacter', function(citizenid)
     local src = source
+    if not Config.EnableDeleteButton then return end
     QBCore.Player.DeleteCharacter(src, citizenid)
     TriggerClientEvent('QBCore:Notify', src, Lang:t("notifications.char_deleted") , "success")
 end)


### PR DESCRIPTION
**Describe Pull request**
This will disallow cheaters (anyone with a LUA script executor) from deleting their characters, bypassing the `Config.EnableDeleteButton` setting. This is done by simply making sure `Config.EnableDeleteButton` is `true`, before deleting the character in `qb-multicharacter:server:deleteCharacter`

If your PR is to fix an issue mention that issue here
#253

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
