### PR TITLE
improve: safe check for qb-apartement availability

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -182,7 +182,7 @@ end)
 
 -- NUI Callbacks
 
-RegisterNUICallback('closeUI', function(_, cb)
+RegisterNUICallback('closeUI', function(data, cb)
     local cData = data.cData
     DoScreenFadeOut(10)
     TriggerServerEvent('qb-multicharacter:server:loadUserData', cData)

--- a/client/main.lua
+++ b/client/main.lua
@@ -168,6 +168,7 @@ RegisterNetEvent('qb-multicharacter:client:spawnLastLocation', function(coords, 
             end
         end, cData.citizenid)
     else
+        local ped = PlayerPedId()
         SetEntityCoords(ped, coords.x, coords.y, coords.z)
         SetEntityHeading(ped, coords.w)
         FreezeEntityPosition(ped, false)

--- a/client/main.lua
+++ b/client/main.lua
@@ -137,35 +137,46 @@ RegisterNetEvent('qb-multicharacter:client:chooseChar', function()
 end)
 
 RegisterNetEvent('qb-multicharacter:client:spawnLastLocation', function(coords, cData)
-    QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', function(result)
-        if result then
-            TriggerEvent('apartments:client:SetHomeBlip', result.type)
-            local ped = PlayerPedId()
-            SetEntityCoords(ped, coords.x, coords.y, coords.z)
-            SetEntityHeading(ped, coords.w)
-            FreezeEntityPosition(ped, false)
-            SetEntityVisible(ped, true)
-            local PlayerData = QBCore.Functions.GetPlayerData()
-            local insideMeta = PlayerData.metadata['inside']
-            DoScreenFadeOut(500)
-
-            if insideMeta.house then
-                TriggerEvent('qb-houses:client:LastLocationHouse', insideMeta.house)
-            elseif insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId then
-                TriggerEvent('qb-apartments:client:LastLocationHouse', insideMeta.apartment.apartmentType, insideMeta.apartment.apartmentId)
-            else
+    if GetResourceState('qb-apartement') == 'started' then
+        QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', function(result)
+            if result then
+                TriggerEvent('apartments:client:SetHomeBlip', result.type)
+                local ped = PlayerPedId()
                 SetEntityCoords(ped, coords.x, coords.y, coords.z)
                 SetEntityHeading(ped, coords.w)
                 FreezeEntityPosition(ped, false)
                 SetEntityVisible(ped, true)
-            end
+                local PlayerData = QBCore.Functions.GetPlayerData()
+                local insideMeta = PlayerData.metadata['inside']
+                DoScreenFadeOut(500)
 
-            TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
-            TriggerEvent('QBCore:Client:OnPlayerLoaded')
-            Wait(2000)
-            DoScreenFadeIn(250)
-        end
-    end, cData.citizenid)
+                if insideMeta.house then
+                    TriggerEvent('qb-houses:client:LastLocationHouse', insideMeta.house)
+                elseif insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId then
+                    TriggerEvent('qb-apartments:client:LastLocationHouse', insideMeta.apartment.apartmentType, insideMeta.apartment.apartmentId)
+                else
+                    SetEntityCoords(ped, coords.x, coords.y, coords.z)
+                    SetEntityHeading(ped, coords.w)
+                    FreezeEntityPosition(ped, false)
+                    SetEntityVisible(ped, true)
+                end
+
+                TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
+                TriggerEvent('QBCore:Client:OnPlayerLoaded')
+                Wait(2000)
+                DoScreenFadeIn(250)
+            end
+        end, cData.citizenid)
+    else
+        SetEntityCoords(ped, coords.x, coords.y, coords.z)
+        SetEntityHeading(ped, coords.w)
+        FreezeEntityPosition(ped, false)
+        SetEntityVisible(ped, true)
+        TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
+        TriggerEvent('QBCore:Client:OnPlayerLoaded')
+        Wait(2000)
+        DoScreenFadeIn(250)
+    end
 end)
 
 -- NUI Callbacks


### PR DESCRIPTION


**Describe Pull request**
a fallback if the qb-apartment isn't started yet, sometimes users mess up some codes in the **qb-apartement** which cause a start failure, we want to make sure that our **qb-multicharacter** started smothly and as less unexpected bugs as possible.

This PR will prevent black screen that the most of qbfx user are facing since the last years based on the community I used to be around.

**Questions:**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
